### PR TITLE
feat: add measure overloads for an optional faster implementation

### DIFF
--- a/stanza/base/protocols.py
+++ b/stanza/base/protocols.py
@@ -1,4 +1,4 @@
-from typing import Protocol, runtime_checkable
+from typing import Protocol, overload, runtime_checkable
 
 
 @runtime_checkable
@@ -22,8 +22,18 @@ class ControlInstrument(Protocol):
 class MeasurementInstrument(Protocol):
     """Protocol for measurement instruments."""
 
+    @overload
     def measure(self, channel_name: str) -> float:
         """Measure the current on a specific channel."""
+        ...
+
+    @overload
+    def measure(self, channel_name: list[str]) -> list[float]:
+        """Optional overload for measuring the current on multiple channels."""
+        ...
+
+    def measure(self, channel_name: str | list[str]) -> float | list[float]:
+        """Measure the current on a specific channel(s)."""
         ...
 
 

--- a/stanza/device.py
+++ b/stanza/device.py
@@ -174,7 +174,17 @@ class Device:
         if isinstance(pad, str):
             return self._measure(pad)
         else:
-            return [self._measure(p) for p in pad]
+            if (
+                self.measurement_instrument
+                and hasattr(self.measurement_instrument, "measure")
+                and callable(self.measurement_instrument.measure)
+            ):
+                try:
+                    return self.measurement_instrument.measure(pad)
+                except Exception as _:
+                    return [self._measure(p) for p in pad]
+            else:
+                return [self._measure(p) for p in pad]
 
     def _check(self, pad: str) -> float:
         """Check the current voltage of a single gate electrode."""

--- a/tests/test_qdac2_pyvisa_sim/test_qdac2_pyvisa_sim.py
+++ b/tests/test_qdac2_pyvisa_sim/test_qdac2_pyvisa_sim.py
@@ -127,7 +127,6 @@ class TestQDAC2PyVisaSim:
     def test_current_measurement(self, qdac2_sim):
         """Test current measurement on measurement channels."""
         current = qdac2_sim.measure("sense1")
-        # Should return the default current value from simulation
         assert current == pytest.approx(0.000001, rel=1e-9)
 
     def test_multiple_channels(self, qdac2_sim):


### PR DESCRIPTION
- Add a `measure` function overload to the `MeasurementInstrument` protocol for an optional faster implementation when multiple electrodes are being measured.
- Add the `measure` overload for the qdac2 driver