### PR TITLE
fix: health check routine wording fixes

### DIFF
--- a/tests/test_analysis_fitting.py
+++ b/tests/test_analysis_fitting.py
@@ -173,9 +173,9 @@ class TestFitPinchoffParameters:
         currents = pinchoff_curve(voltages, 1.0, 1.0, 1.0)
         result = fit_pinchoff_parameters(voltages, currents)
         assert isinstance(result, PinchoffFitResult)
-        assert result.v_pinch_off is not None
-        assert result.v_transition is not None
         assert result.v_cut_off is not None
+        assert result.v_transition is not None
+        assert result.v_saturation is not None
         assert result.popt is not None
         assert result.pcov is not None
 
@@ -184,7 +184,7 @@ class TestFitPinchoffParameters:
         currents = pinchoff_curve(voltages, 1.0, 1.0, 1.0)
         noisy_currents = currents + np.random.normal(0, 0.01, len(currents))
         result = fit_pinchoff_parameters(voltages, noisy_currents)
-        assert result.v_pinch_off is not None
+        assert result.v_cut_off is not None
 
     def test_fit_parameter_shapes(self):
         voltages = np.linspace(-10, 10, 100)
@@ -197,15 +197,15 @@ class TestFitPinchoffParameters:
         voltages = np.linspace(-10, 10, 100)
         currents = pinchoff_curve(voltages, 1.0, 1.0, 1.0)
         result = fit_pinchoff_parameters(voltages, currents, sigma=0.05)
-        assert result.v_pinch_off is not None
+        assert result.v_cut_off is not None
 
     def test_edge_case_out_of_bounds_index(self):
         voltages = np.linspace(-10, 10, 10)
         currents = pinchoff_curve(voltages, 1.0, 1.0, 1.0)
         result = fit_pinchoff_parameters(voltages, currents)
-        assert hasattr(result, "v_pinch_off")
-        assert hasattr(result, "v_transition")
         assert hasattr(result, "v_cut_off")
+        assert hasattr(result, "v_transition")
+        assert hasattr(result, "v_saturation")
 
     def test_very_flat_curve(self):
         """Test fitting with very flat curve (minimal slope)."""
@@ -233,7 +233,7 @@ class TestFitPinchoffParameters:
         currents = pinchoff_curve(voltages, 1e-9, 2.0, -1.0)
         result = fit_pinchoff_parameters(voltages, currents)
 
-        assert result.v_pinch_off is not None
+        assert result.v_cut_off is not None
         assert result.i_min < result.i_max
         fitted_currents = result.fit_curve(voltages)
         assert fitted_currents.min() >= 0
@@ -244,7 +244,7 @@ class TestFitPinchoffParameters:
         currents = pinchoff_curve(voltages * 100, 0.5, 2.0, -1.0)
         result = fit_pinchoff_parameters(voltages, currents)
 
-        assert result.v_pinch_off is not None
+        assert result.v_cut_off is not None
         assert result.v_min < result.v_max
 
     def test_inverted_curve_comprehensive(self):
@@ -253,10 +253,10 @@ class TestFitPinchoffParameters:
         currents = pinchoff_curve(voltages, 0.5, -2.0, 1.0)
         result = fit_pinchoff_parameters(voltages, currents)
 
-        assert result.v_pinch_off is not None
-        assert result.v_transition is not None
         assert result.v_cut_off is not None
-        assert result.v_pinch_off > result.v_cut_off
+        assert result.v_transition is not None
+        assert result.v_saturation is not None
+        assert result.v_cut_off > result.v_saturation
 
     def test_very_steep_curve(self):
         """Test with very steep transition."""
@@ -264,8 +264,8 @@ class TestFitPinchoffParameters:
         currents = pinchoff_curve(voltages, 1.0, 20.0, 0.0)
         result = fit_pinchoff_parameters(voltages, currents, sigma=1.0)
 
-        assert result.v_pinch_off is not None
-        assert abs(result.v_cut_off - result.v_pinch_off) < 1.0
+        assert result.v_cut_off is not None
+        assert abs(result.v_saturation - result.v_cut_off) < 1.0
 
     def test_poor_fit_detection(self):
         """Test that a very poor fit can be detected via high residuals."""
@@ -290,7 +290,7 @@ class TestFitPinchoffParameters:
         currents = np.ones_like(voltages) * 5.0
         result = fit_pinchoff_parameters(voltages, currents)
 
-        assert result.v_pinch_off is not None
+        assert result.v_cut_off is not None
         assert result.popt is not None
 
     def test_non_monotonic_data(self):
@@ -300,7 +300,7 @@ class TestFitPinchoffParameters:
         currents = base_curve + 0.1 * np.sin(voltages * 3)
         result = fit_pinchoff_parameters(voltages, currents, sigma=3.0)
 
-        assert result.v_pinch_off is not None
+        assert result.v_cut_off is not None
         fitted_currents = result.fit_curve(voltages)
 
         fit_variation = np.std(np.diff(fitted_currents))
@@ -312,7 +312,7 @@ class TestFitPinchoffParameters:
         voltages = np.linspace(-1000, 1000, 200)
         currents = pinchoff_curve(voltages / 1000, 0.5, 2.0, -1.0)
         result = fit_pinchoff_parameters(voltages, currents)
-        assert result.v_pinch_off is not None
+        assert result.v_cut_off is not None
         assert result.v_min == voltages.min()
         assert result.v_max == voltages.max()
 
@@ -322,8 +322,8 @@ class TestFitPinchoffParameters:
         currents = pinchoff_curve((voltages - 20) / 10, 0.5, 2.0, -1.0)
         result = fit_pinchoff_parameters(voltages, currents)
 
-        assert result.v_pinch_off is not None
-        assert voltages.min() <= result.v_pinch_off <= voltages.max()
+        assert result.v_cut_off is not None
+        assert voltages.min() <= result.v_cut_off <= voltages.max()
 
     def test_fit_quality_good_fit(self):
         """Test that a good fit has low residuals and reasonable covariance."""

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -377,14 +377,14 @@ class TestAnalyzeSingleGateHeuristic:
         currents_noisy = currents + noise
 
         result = analyze_single_gate_heuristic(voltages, currents_noisy)
-        assert "vp" in result
-        assert "vt" in result
-        assert "vc" in result
+        assert "cutoff_voltage" in result
+        assert "transition_voltage" in result
+        assert "saturation_voltage" in result
         assert "popt" in result
         assert "pcov" in result
-        assert isinstance(result["vp"], float)
-        assert isinstance(result["vt"], float)
-        assert isinstance(result["vc"], float)
+        assert isinstance(result["cutoff_voltage"], float)
+        assert isinstance(result["transition_voltage"], float)
+        assert isinstance(result["saturation_voltage"], float)
 
     def test_negative_amplitude_curve(self):
         voltages = np.linspace(-2, 2, 200)
@@ -396,10 +396,14 @@ class TestAnalyzeSingleGateHeuristic:
         currents_noisy = currents + noise
 
         result = analyze_single_gate_heuristic(voltages, currents_noisy)
-        assert "vp" in result
-        assert "vt" in result
-        assert "vc" in result
-        assert result["vc"] < result["vt"] < result["vp"]
+        assert "cutoff_voltage" in result
+        assert "transition_voltage" in result
+        assert "saturation_voltage" in result
+        assert (
+            result["saturation_voltage"]
+            < result["transition_voltage"]
+            < result["cutoff_voltage"]
+        )
 
 
 class TestLeakageHelperFunctions:


### PR DESCRIPTION
Fixes in the nomenclature for health check routines.

- Change `vp`, `vt`, and `vc` to `cutoff_voltage`, `transition_voltage`, and `saturation_voltage`, respectively.
- Fix docstrings for the analysis module.