### PR TITLE
default zero all pads for device.zero()

### DIFF
--- a/stanza/device.py
+++ b/stanza/device.py
@@ -557,7 +557,7 @@ class Device:
 
         Args:
             type: Specifies which pads to zero. Options are:
-                - PadType.ALL or "ALL": Zero all control gates and contacts (default)
+                - PadType.ALL or "ALL": Zero all control gates, contacts, and gpios (default)
                 - PadType.GATE or "GATE": Zero only control gates
                 - PadType.CONTACT or "CONTACT": Zero only control contacts
                 - PadType.GPIO or "GPIO": Zero only control gpios

--- a/stanza/device.py
+++ b/stanza/device.py
@@ -78,6 +78,15 @@ class Device:
         ]
 
     @property
+    def gpios(self) -> list[str]:
+        """List of all gpio pad names in the device."""
+        return [
+            channel.name
+            for channel in self.channel_configs.values()
+            if channel.pad_type == PadType.GPIO
+        ]
+
+    @property
     def control_gates(self) -> list[str]:
         """List of gate pads that have a control channel configured."""
         return [
@@ -94,6 +103,15 @@ class Device:
             for channel in self.channel_configs.values()
             if channel.pad_type == PadType.CONTACT
             and channel.control_channel is not None
+        ]
+
+    @property
+    def control_gpios(self) -> list[str]:
+        """List of gpio pads that have a control channel configured."""
+        return [
+            channel.name
+            for channel in self.channel_configs.values()
+            if channel.pad_type == PadType.GPIO and channel.control_channel is not None
         ]
 
     @property
@@ -542,6 +560,7 @@ class Device:
                 - PadType.ALL or "ALL": Zero all control gates and contacts (default)
                 - PadType.GATE or "GATE": Zero only control gates
                 - PadType.CONTACT or "CONTACT": Zero only control contacts
+                - PadType.GPIO or "GPIO": Zero only control gpios
                 Can be provided as PadType enum or case-insensitive string.
 
         Raises:
@@ -550,11 +569,13 @@ class Device:
         """
         pads: list[str] = []
         if str(type).upper() == PadType.ALL:
-            pads = self.control_gates + self.control_contacts
+            pads = self.control_gates + self.control_contacts + self.control_gpios
         elif str(type).upper() == PadType.GATE:
             pads = self.control_gates
         elif str(type).upper() == PadType.CONTACT:
             pads = self.control_contacts
+        elif str(type).upper() == PadType.GPIO:
+            pads = self.control_gpios
         else:
             raise DeviceError(f"Invalid pad type: {type}")
 

--- a/stanza/models.py
+++ b/stanza/models.py
@@ -214,7 +214,7 @@ class DeviceConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_unique_channels(self) -> "DeviceConfig":
-        """Ensure that all channels are unique across gates and contacts"""
+        """Ensure that all channels are unique across gates, contacts, and gpios"""
         control_channel_users: dict[int, list[str]] = {}
         measure_channel_users: dict[int, list[str]] = {}
         duplicates = []

--- a/stanza/routines/builtins/health_check.py
+++ b/stanza/routines/builtins/health_check.py
@@ -16,7 +16,7 @@ from stanza.analysis.criterion import fit_quality_criterion
 from stanza.analysis.fitting import fit_pinchoff_parameters
 from stanza.exceptions import RoutineError
 from stanza.logger.session import LoggerSession
-from stanza.models import GateType, PadType
+from stanza.models import GateType
 from stanza.routines import RoutineContext, routine
 
 logger = logging.getLogger(__name__)
@@ -56,7 +56,12 @@ def noise_floor_measurement(
         - The current_std value is commonly used in leakage_test as min_current_threshold
     """
     currents = []
-    ctx.resources.device.zero(PadType.ALL)
+    ctx.resources.device.jump(
+        dict.fromkeys(
+            ctx.resources.device.control_gates + ctx.resources.device.control_contacts,
+            0.0,
+        )
+    )
     for _ in range(num_points):
         current = ctx.resources.device.measure(measure_electrode)
         currents.append(current)

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -26,6 +26,7 @@ class MockDevice:
     def __init__(self):
         self.name = "device"
         self.control_gates = ["G1", "G2", "G3"]
+        self.control_contacts = []
         self.voltages = dict.fromkeys(self.control_gates, 0.0)
         self.currents = dict.fromkeys(self.control_gates, 1e-11)
         self.channel_configs = {


### PR DESCRIPTION
- default to zeroing all pads (including gpio PadType) when `device.zero()` is called.