### PR TITLE
fix parent parameter inheritance for routine runner

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,7 +248,7 @@ routines:
   - name: health_check
     parameters:
       parent_param: value
-      type: holes
+      charge_carrier_type: holes
     routines:
       - name: leakage_test
         parameters:


### PR DESCRIPTION
- Fix parent parameter inheritance when calling `RoutineRunner.run(...)`