### PR TITLE
add percent threshold heuristic to pinch off fit

### DIFF
--- a/stanza/routines/builtins/health_check.py
+++ b/stanza/routines/builtins/health_check.py
@@ -769,7 +769,7 @@ def analyze_single_gate_heuristic(
         ValueError: If the curve fit quality is poor based on R² and NRMSE metrics.
     """
 
-    pinchoff_fit = fit_pinchoff_parameters(voltages, currents)
+    pinchoff_fit = fit_pinchoff_parameters(voltages, currents, percent_threshold=0.05)
     y_pred = pinchoff_fit.fit_curve(voltages)
     is_good_fit = fit_quality_criterion(voltages, currents, y_pred)
 

--- a/tests/test_analysis_fitting.py
+++ b/tests/test_analysis_fitting.py
@@ -6,7 +6,7 @@ from stanza.analysis.fitting import (
     _compute_initial_params,
     _compute_parameter_bounds,
     _map_index_to_voltage,
-    compute_cutoff_from_threshold,
+    compute_indices_from_threshold,
     derivative_extrema_indices,
     fit_pinchoff_parameters,
     pinchoff_curve,
@@ -148,62 +148,94 @@ class TestMapIndexToVoltage:
         assert _map_index_to_voltage(10, voltages) is None
 
 
-class TestComputeCutoffFromThreshold:
+class TestComputeIndicesFromThresholds:
     def test_basic_threshold_normal_curve(self):
         """Test threshold detection on normal (increasing) curve."""
         fitted_current = np.array([0.0, 0.1, 0.5, 0.9, 1.0])
-        cutoff_idx = compute_cutoff_from_threshold(fitted_current, 0.05)
+        cutoff_idx, saturation_idx = compute_indices_from_threshold(
+            fitted_current, 0.05
+        )
         assert isinstance(cutoff_idx, int)
+        assert isinstance(saturation_idx, int)
         assert 0 <= cutoff_idx < len(fitted_current)
-        assert fitted_current[cutoff_idx] >= 0.05
+        assert 0 <= saturation_idx < len(fitted_current)
+        assert cutoff_idx < saturation_idx
+
+        min_threshold = 0.0 + 0.05 * 1.0  # 0.05
+        max_threshold = 1.0 - 0.05 * 1.0  # 0.95
+        assert fitted_current[cutoff_idx] >= min_threshold
+        assert fitted_current[saturation_idx] >= max_threshold
 
     def test_basic_threshold_inverted_curve(self):
         """Test threshold detection on inverted (decreasing) curve."""
         fitted_current = np.array([1.0, 0.9, 0.5, 0.1, 0.0])
-        cutoff_idx = compute_cutoff_from_threshold(fitted_current, 0.05)
+        cutoff_idx, saturation_idx = compute_indices_from_threshold(
+            fitted_current, 0.05
+        )
         assert isinstance(cutoff_idx, int)
+        assert isinstance(saturation_idx, int)
         assert 0 <= cutoff_idx < len(fitted_current)
-        assert fitted_current[cutoff_idx] <= 0.95
+        assert 0 <= saturation_idx < len(fitted_current)
+        assert saturation_idx < cutoff_idx
+
+        min_threshold = 0.0 + 0.05 * 1.0  # 0.05
+        max_threshold = 1.0 - 0.05 * 1.0  # 0.95
+        assert fitted_current[cutoff_idx] <= min_threshold
+        assert fitted_current[saturation_idx] <= max_threshold
 
     def test_threshold_with_tanh_curve(self):
         """Test threshold on realistic tanh-based pinchoff curve."""
         x = np.linspace(-3, 3, 300)
         fitted_current = 0.5 * (1 + np.tanh(2.0 * x + 1.0))
-        cutoff_idx = compute_cutoff_from_threshold(fitted_current, 0.03)
-        # For this curve, 3% threshold should detect cutoff early
+        cutoff_idx, saturation_idx = compute_indices_from_threshold(
+            fitted_current, 0.03
+        )
         assert cutoff_idx < len(fitted_current) / 3
+        assert saturation_idx > cutoff_idx
 
     def test_different_threshold_values(self):
         """Test that higher thresholds give later cutoff indices."""
         x = np.linspace(-3, 3, 300)
         fitted_current = 0.5 * (1 + np.tanh(2.0 * x + 1.0))
-        idx_3pct = compute_cutoff_from_threshold(fitted_current, 0.03)
-        idx_5pct = compute_cutoff_from_threshold(fitted_current, 0.05)
-        idx_10pct = compute_cutoff_from_threshold(fitted_current, 0.10)
-        assert idx_3pct < idx_5pct < idx_10pct
+        cutoff_3pct, sat_3pct = compute_indices_from_threshold(fitted_current, 0.03)
+        cutoff_5pct, sat_5pct = compute_indices_from_threshold(fitted_current, 0.05)
+        cutoff_10pct, sat_10pct = compute_indices_from_threshold(fitted_current, 0.10)
+        assert cutoff_3pct < cutoff_5pct < cutoff_10pct
+        assert sat_3pct > sat_5pct > sat_10pct
 
     def test_inverted_curve_threshold_ordering(self):
         """Test that higher thresholds give earlier cutoff for inverted curves."""
         x = np.linspace(-3, 3, 300)
         fitted_current = 1.0 - 0.5 * (1 + np.tanh(2.0 * x + 1.0))
-        idx_3pct = compute_cutoff_from_threshold(fitted_current, 0.03)
-        idx_5pct = compute_cutoff_from_threshold(fitted_current, 0.05)
-        idx_10pct = compute_cutoff_from_threshold(fitted_current, 0.10)
-        # For inverted, higher threshold detects cutoff earlier
-        assert idx_3pct > idx_5pct > idx_10pct
+        cutoff_3pct, sat_3pct = compute_indices_from_threshold(fitted_current, 0.03)
+        cutoff_5pct, sat_5pct = compute_indices_from_threshold(fitted_current, 0.05)
+        cutoff_10pct, sat_10pct = compute_indices_from_threshold(fitted_current, 0.10)
+        assert cutoff_3pct > cutoff_5pct > cutoff_10pct
+        assert sat_3pct < sat_5pct < sat_10pct
 
     def test_zero_threshold(self):
-        """Test with 0% threshold (should find first point)."""
+        """Test with 0% threshold (should find first and last points)."""
         fitted_current = np.linspace(0, 1, 100)
-        cutoff_idx = compute_cutoff_from_threshold(fitted_current, 0.0)
+        cutoff_idx, saturation_idx = compute_indices_from_threshold(fitted_current, 0.0)
         assert cutoff_idx == 0
+        assert saturation_idx == len(fitted_current) - 1
 
     def test_full_threshold(self):
-        """Test with 100% threshold (should find last point or close to it)."""
+        """Test with 50% threshold (should find points near middle)."""
         fitted_current = np.linspace(0, 1, 100)
-        cutoff_idx = compute_cutoff_from_threshold(fitted_current, 1.0)
-        # Should be near the end
-        assert cutoff_idx >= len(fitted_current) - 2
+        cutoff_idx, saturation_idx = compute_indices_from_threshold(fitted_current, 0.5)
+        assert 45 <= cutoff_idx <= 55
+        assert 45 <= saturation_idx <= 55
+
+    def test_return_tuple(self):
+        """Test that function returns a tuple of two integers."""
+        fitted_current = np.linspace(0, 1, 100)
+        result = compute_indices_from_threshold(fitted_current, 0.1)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        cutoff_idx, saturation_idx = result
+        assert isinstance(cutoff_idx, int)
+        assert isinstance(saturation_idx, int)
 
 
 class TestPinchoffFitResult:
@@ -403,24 +435,8 @@ class TestFitPinchoffParameters:
         param_uncertainties = np.sqrt(np.diag(result.pcov))
         assert np.all(param_uncertainties < 0.1), "Expected low parameter uncertainties"
 
-    def test_percent_threshold_parameter(self):
-        """Test that percent_threshold parameter changes cutoff voltage."""
-        voltages = np.linspace(-3, 3, 300)
-        currents = pinchoff_curve(voltages, 0.5, 2.0, 1.0)
-        currents += np.random.normal(0, 0.02, len(currents))
-
-        result_derivative = fit_pinchoff_parameters(voltages, currents)
-        result_threshold = fit_pinchoff_parameters(
-            voltages, currents, percent_threshold=0.05
-        )
-
-        assert result_threshold.v_cut_off != result_derivative.v_cut_off
-        # Transition and saturation should remain the same
-        assert result_threshold.v_transition == result_derivative.v_transition
-        assert result_threshold.v_saturation == result_derivative.v_saturation
-
     def test_percent_threshold_multiple_values(self):
-        """Test that different threshold values produce different cutoffs."""
+        """Test that different threshold values produce different cutoffs and saturations."""
         voltages = np.linspace(-3, 3, 300)
         currents = pinchoff_curve(voltages, 0.5, 2.0, 1.0)
 
@@ -436,9 +452,15 @@ class TestFitPinchoffParameters:
 
         # Higher thresholds should give later (higher) cutoff voltages for normal curves
         assert result_3pct.v_cut_off < result_4pct.v_cut_off < result_5pct.v_cut_off
+        # Higher thresholds should give earlier (lower) saturation voltages for normal curves
+        assert (
+            result_3pct.v_saturation
+            > result_4pct.v_saturation
+            > result_5pct.v_saturation
+        )
 
     def test_percent_threshold_vs_derivative_comparison(self):
-        """Test that threshold method detects cutoff earlier than derivative method."""
+        """Test that threshold method detects cutoff and saturation differently than derivative method."""
         voltages = np.linspace(-3, 3, 300)
         currents = pinchoff_curve(voltages, 0.5, 2.0, 1.0)
         currents += np.random.normal(0, 0.02, len(currents))
@@ -450,6 +472,8 @@ class TestFitPinchoffParameters:
 
         # Threshold method should typically detect cutoff earlier (lower voltage)
         assert result_threshold.v_cut_off < result_derivative.v_cut_off
+        # Threshold method should typically detect saturation later (higher voltage)
+        assert result_threshold.v_saturation > result_derivative.v_saturation
 
     def test_percent_threshold_inverted_curve(self):
         """Test threshold method on inverted pinchoff curve."""
@@ -462,9 +486,11 @@ class TestFitPinchoffParameters:
         )
 
         assert result_threshold.v_cut_off is not None
+        assert result_threshold.v_saturation is not None
         assert result_threshold.v_cut_off != result_derivative.v_cut_off
-        # For inverted curves, cutoff should be at higher voltage
-        assert result_threshold.v_cut_off > result_derivative.v_saturation
+        assert result_threshold.v_saturation != result_derivative.v_saturation
+        # For inverted curves, cutoff should be at higher voltage than saturation
+        assert result_threshold.v_cut_off > result_threshold.v_saturation
 
     def test_percent_threshold_with_noise(self):
         """Test threshold method robustness with noisy data."""
@@ -477,7 +503,9 @@ class TestFitPinchoffParameters:
         )
 
         assert result.v_cut_off is not None
+        assert result.v_saturation is not None
         assert voltages.min() <= result.v_cut_off <= voltages.max()
+        assert voltages.min() <= result.v_saturation <= voltages.max()
 
     def test_percent_threshold_preserves_fit_parameters(self):
         """Test that threshold parameter doesn't affect fitted parameters."""


### PR DESCRIPTION
- Add a percent threshold parameter to the `fit_pinchoff_parameters` in the `stanza.analysis` module to provide a better cut off voltage.