### PR TITLE
feat: add setup models sdk subroutine

### DIFF
--- a/stanza/routines/builtins/__init__.py
+++ b/stanza/routines/builtins/__init__.py
@@ -7,8 +7,10 @@ from stanza.routines.builtins.health_check import (
     noise_floor_measurement,
     reservoir_characterization,
 )
+from stanza.routines.builtins.setup import setup_models_sdk
 
 __all__ = [
+    "setup_models_sdk",
     "noise_floor_measurement",
     "leakage_test",
     "global_accumulation",

--- a/stanza/routines/builtins/setup.py
+++ b/stanza/routines/builtins/setup.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+from conductorquantum import ConductorQuantum
+
+from stanza.logger.session import LoggerSession
+from stanza.routines.core import RoutineContext, routine
+
+
+@routine
+def setup_models_sdk(
+    ctx: RoutineContext, token: str, session: LoggerSession | None = None, **kwargs: Any
+) -> None:
+    """
+    Instantiate the Conductor Quantum SDK and add it to the context.
+
+    Args:
+        ctx: The context object
+        token: The token for the conductor quantum models client
+    """
+    client = ConductorQuantum(token=token)
+    ctx.resources.add("models_client", client)

--- a/tests/test_setup_routines.py
+++ b/tests/test_setup_routines.py
@@ -1,0 +1,93 @@
+"""Tests for setup routines."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from stanza.registry import ResourceRegistry, ResultsRegistry
+from stanza.routines import RoutineContext
+from stanza.routines.builtins.setup import setup_models_sdk
+
+
+class MockLoggerSession:
+    def __init__(self):
+        self.measurements = []
+        self.analyses = []
+
+    def log_measurement(self, name, data):
+        self.measurements.append((name, data))
+
+    def log_analysis(self, name, data):
+        self.analyses.append((name, data))
+
+
+@pytest.fixture
+def routine_context():
+    return RoutineContext(ResourceRegistry(), ResultsRegistry())
+
+
+class TestSetupModelsSDK:
+    @patch("stanza.routines.builtins.setup.ConductorQuantum")
+    def test_basic_setup(self, mock_cq_class, routine_context):
+        """Test that setup_models_sdk creates and registers a client."""
+        mock_client = MagicMock()
+        mock_cq_class.return_value = mock_client
+
+        token = "test-token-123"
+        setup_models_sdk(routine_context, token=token)
+
+        mock_cq_class.assert_called_once_with(token=token)
+
+        assert hasattr(routine_context.resources, "models_client")
+        assert routine_context.resources.models_client == mock_client
+
+    @patch("stanza.routines.builtins.setup.ConductorQuantum")
+    def test_setup_with_session(self, mock_cq_class, routine_context):
+        """Test that setup_models_sdk works with a logger session."""
+        mock_client = MagicMock()
+        mock_cq_class.return_value = mock_client
+        session = MockLoggerSession()
+
+        token = "test-token-456"
+        setup_models_sdk(routine_context, token=token, session=session)
+
+        mock_cq_class.assert_called_once_with(token=token)
+
+        assert hasattr(routine_context.resources, "models_client")
+        assert routine_context.resources.models_client == mock_client
+
+    @patch("stanza.routines.builtins.setup.ConductorQuantum")
+    def test_setup_returns_none(self, mock_cq_class, routine_context):
+        """Test that setup_models_sdk returns None."""
+        mock_client = MagicMock()
+        mock_cq_class.return_value = mock_client
+
+        result = setup_models_sdk(routine_context, token="test-token")
+
+        assert result is None
+
+    @patch("stanza.routines.builtins.setup.ConductorQuantum")
+    def test_client_accessible_after_setup(self, mock_cq_class, routine_context):
+        """Test that the client can be accessed from context after setup."""
+        mock_client = MagicMock()
+        mock_client.some_method = MagicMock(return_value="test_value")
+        mock_cq_class.return_value = mock_client
+
+        setup_models_sdk(routine_context, token="test-token")
+
+        client = routine_context.resources.models_client
+        assert client.some_method() == "test_value"
+        client.some_method.assert_called_once()
+
+    @patch("stanza.routines.builtins.setup.ConductorQuantum")
+    def test_setup_with_kwargs(self, mock_cq_class, routine_context):
+        """Test that setup_models_sdk handles additional kwargs."""
+        mock_client = MagicMock()
+        mock_cq_class.return_value = mock_client
+
+        setup_models_sdk(
+            routine_context, token="test-token", extra_param="value", another_param=123
+        )
+
+        mock_cq_class.assert_called_once_with(token="test-token")
+        assert hasattr(routine_context.resources, "models_client")


### PR DESCRIPTION
- add setup_models_sdk subroutine to stanza to initialize the conductorquantum models sdk.