### PR TITLE
Support explicit DataLogger base directory overrides

### DIFF
--- a/stanza/logger/data_logger.py
+++ b/stanza/logger/data_logger.py
@@ -47,10 +47,10 @@ class DataLogger:
 
         self.name = name
         self.routine_name = routine_name
-        dir_name = routine_dir_name or self.routine_name
-        dir_name = self._slugify(dir_name)
-        self.base_directory = Path(base_dir) / dir_name
-        self.base_directory.mkdir(parents=True, exist_ok=True)
+        self._routine_dir_name = self._slugify(routine_dir_name or self.routine_name)
+        self._base_dir_root = Path(base_dir)
+        self.base_directory = Path()
+        self.set_base_directory(self._base_dir_root)
 
         if formats is None:
             formats = ["jsonl"]
@@ -71,6 +71,12 @@ class DataLogger:
         # Auto-enable live plotting if configured via CLI
         if bokeh_backend is None:
             self._auto_enable_live_plotting()
+
+    def set_base_directory(self, base_dir: str | Path) -> None:
+        """Update the base directory where sessions will be created."""
+        self._base_dir_root = Path(base_dir)
+        self.base_directory = self._base_dir_root / self._routine_dir_name
+        self.base_directory.mkdir(parents=True, exist_ok=True)
 
     def _auto_enable_live_plotting(self) -> None:
         """Auto-enable live plotting if configured."""

--- a/stanza/routines/core.py
+++ b/stanza/routines/core.py
@@ -300,7 +300,7 @@ class RoutineRunner:
         data_logger = getattr(self.resources, "logger", None)
         session = None
         if data_logger is not None and hasattr(data_logger, "create_session"):
-            self._maybe_update_logger_base_dir()
+            self._update_logger_base_dir_if_needed()
             session_id = self._get_routine_path(routine_name)
             session = data_logger.create_session(
                 session_id=session_id, group_name=group_name
@@ -330,7 +330,7 @@ class RoutineRunner:
         """Override the logger base directory or revert to session-based resolution."""
         self._base_dir_override = Path(base_dir) if base_dir is not None else None
         self._manages_logger_base_dir = True
-        self._maybe_update_logger_base_dir()
+        self._update_logger_base_dir_if_needed()
 
     def _resolve_base_dir(self) -> Path:
         """Resolve base directory from override or current active session."""
@@ -343,8 +343,8 @@ class RoutineRunner:
 
         return Path("./data")
 
-    def _maybe_update_logger_base_dir(self) -> None:
-        """Update logger base directory if managed by the runner."""
+    def _update_logger_base_dir_if_needed(self) -> None:
+        """Synchronize the logger base directory if the runner manages it."""
         if not (self._manages_logger_base_dir or self._base_dir_override is not None):
             return
 


### PR DESCRIPTION
RoutineRunner accepts an optional base_dir argument and exposes set_logger_base_dir(), letting scripts explicitly choose the logging directory via the runner instead of instantiating their own DataLogger or relying on the global active session. The runner refreshes the logger root before each session so looped workflows pick up per-device paths.