### PR TITLE
Add delete session to cli

### DIFF
--- a/stanza/cli.py
+++ b/stanza/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import webbrowser
 from datetime import datetime
 from pathlib import Path
@@ -99,6 +100,55 @@ def status() -> None:
     if metadata:
         created = datetime.fromtimestamp(metadata["created_at"])
         click.echo(f"  Created: {created.strftime('%Y-%m-%d %H:%M:%S')}")
+
+
+@cli.command("delete-session", short_help="Delete the current active session.")
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Delete without confirmation prompt.",
+)
+@click.option(
+    "--keep-data",
+    is_flag=True,
+    help="Only clear the active session pointer without deleting files.",
+)
+def delete_session(force: bool, keep_data: bool) -> None:
+    """Delete the active session directory or clear the pointer."""
+    active_session = StanzaSession.get_active_session()
+
+    if active_session is None:
+        click.echo("No active session to delete")
+        return
+
+    if keep_data:
+        StanzaSession.clear_active_session()
+        click.echo(f"✓ Active session cleared (data kept at {active_session})")
+        return
+
+    if not active_session.exists():
+        StanzaSession.clear_active_session()
+        click.echo("Active session directory was not found. Pointer cleared.")
+        return
+
+    if not force:
+        prompt = (
+            f"This will permanently delete '{active_session}' and all contents. Continue?"
+        )
+        if not click.confirm(prompt, default=False):
+            click.echo("Deletion cancelled.")
+            return
+
+    try:
+        shutil.rmtree(active_session)
+    except Exception as e:
+        click.echo(f"✗ Failed to delete session directory: {e}", err=True)
+        raise click.Abort() from e
+
+    StanzaSession.clear_active_session()
+
+    click.echo(f"✓ Deleted session directory: {active_session}")
+    click.echo("  Active session cleared.")
 
 
 def _get_config_file() -> Path:

--- a/stanza/cli.py
+++ b/stanza/cli.py
@@ -132,9 +132,7 @@ def delete_session(force: bool, keep_data: bool) -> None:
         return
 
     if not force:
-        prompt = (
-            f"This will permanently delete '{active_session}' and all contents. Continue?"
-        )
+        prompt = f"This will permanently delete '{active_session}' and all contents. Continue?"
         if not click.confirm(prompt, default=False):
             click.echo("Deletion cancelled.")
             return

--- a/stanza/context.py
+++ b/stanza/context.py
@@ -184,6 +184,22 @@ class StanzaSession:
             json.dump(data, f, indent=2)
 
     @staticmethod
+    def clear_active_session() -> bool:
+        """Remove the active session pointer file.
+
+        Returns:
+            True if a session reference was removed, False otherwise.
+        """
+        config_file = Path.cwd() / StanzaSession.CONFIG_DIR / "active_session.json"
+
+        try:
+            config_file.unlink()
+        except FileNotFoundError:
+            return False
+
+        return True
+
+    @staticmethod
     def get_session_metadata(session_dir: Path | str) -> dict[str, Any] | None:
         """Get metadata for a Stanza session directory.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -263,6 +263,42 @@ class TestStatusCommand:
             assert "Created:" not in result.output
 
 
+class TestDeleteSessionCommand:
+    """Test suite for 'stanza delete-session' command."""
+
+    def test_delete_session_keep_data_clears_pointer(self):
+        """Deleting with --keep-data clears the active session pointer."""
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            session_dir = StanzaSession.create_session_directory(base_path=Path.cwd())
+            StanzaSession.set_active_session(session_dir)
+
+            result = runner.invoke(cli, ["delete-session", "--keep-data"])
+
+            assert result.exit_code == 0
+            assert "Active session cleared" in result.output
+            assert session_dir.exists()
+            assert StanzaSession.get_active_session() is None
+
+    def test_delete_session_force_removes_directory(self):
+        """Deleting with --force removes the session directory."""
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            session_dir = StanzaSession.create_session_directory(base_path=Path.cwd())
+            StanzaSession.set_active_session(session_dir)
+
+            assert session_dir.exists()
+
+            result = runner.invoke(cli, ["delete-session", "--force"])
+
+            assert result.exit_code == 0
+            assert "Deleted session directory" in result.output
+            assert not session_dir.exists()
+            assert StanzaSession.get_active_session() is None
+
+
 class TestLivePlotCommand:
     """Test suite for 'stanza live-plot' commands."""
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -244,6 +244,28 @@ class TestStanzaSession:
             finally:
                 os.chdir(original_cwd)
 
+    def test_clear_active_session_removes_pointer_file(self):
+        """Test that clear_active_session deletes the pointer file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_cwd = Path.cwd()
+            import os
+
+            os.chdir(tmpdir)
+            try:
+                session_dir = StanzaSession.create_session_directory(base_path=tmpdir)
+                StanzaSession.set_active_session(session_dir)
+
+                config_file = Path(tmpdir) / ".stanza" / "active_session.json"
+                assert config_file.exists()
+
+                assert StanzaSession.clear_active_session() is True
+                assert not config_file.exists()
+                assert StanzaSession.get_active_session() is None
+
+                assert StanzaSession.clear_active_session() is False
+            finally:
+                os.chdir(original_cwd)
+
     def test_timestamp_format_is_correct(self):
         """Test that session directory timestamp follows YYYYMMDDHHmmss format."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Added a stanza delete-session command so users can clear the pointer (--keep-data) or delete the active session directory (with confirmation or --force). Backed it with a new StanzaSession.clear_active_session() helper and unit tests in both tests/test_context.py and tests/test_cli.py covering pointer removal and CLI flows